### PR TITLE
Fix API_URLの環境変数への登録

### DIFF
--- a/frontend/src/app/login/page.js
+++ b/frontend/src/app/login/page.js
@@ -22,7 +22,7 @@ const Login = () => {
     event.preventDefault();
     const data = new FormData(event.currentTarget);
     const axiosInstance = axios.create({
-      baseURL: `http://localhost:3000/api/v1/`,
+      baseURL: `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/v1/`,
       headers: {
         "content-type": "application/json",
       },

--- a/frontend/src/app/sign-up/page.js
+++ b/frontend/src/app/sign-up/page.js
@@ -22,7 +22,7 @@ const SignUp = () => {
     event.preventDefault();
     const data = new FormData(event.currentTarget);
     const axiosInstance = axios.create({
-      baseURL: `http://localhost:3000/api/v1/`,
+      baseURL: `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/v1/`,
       headers: {
         "content-type": "application/json",
       },


### PR DESCRIPTION
### 概要
APIのURLがlocalhost:3000のままで記述しており、デプロイ時にログインなどのリクエストが送れなくなっていた。
環境変数に登録し、デプロイ先でも使用できるよう修正

### 確認方法
ローカル、デプロイ先でAPIへのリクエストが問題なく行えることを確認