### PR TITLE
リンク先へ遷移時サイドメニューが開いたままになる現象を修正

### DIFF
--- a/frontend/src/components/navigation/navbar.js
+++ b/frontend/src/components/navigation/navbar.js
@@ -51,7 +51,7 @@ const NavBar = () => {
         </Toolbar>
       </AppBar>
       <Drawer open={open} onClose={toggleDrawer}>
-        <Sidemenu />
+        <Sidemenu open={open} setOpen={setOpen} />
       </Drawer>
     </Box>
   );

--- a/frontend/src/components/sidemenu.js
+++ b/frontend/src/components/sidemenu.js
@@ -5,8 +5,15 @@ import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import ArticleOutlinedIcon from "@mui/icons-material/ArticleOutlined";
+import { useRouter } from "next/navigation";
 
-const Sidemenu = () => {
+const Sidemenu = ({ open, setOpen }) => {
+  const router = useRouter();
+
+  const ToIndexArticle = () => {
+    router.push("/article/index");
+    setOpen(!open);
+  };
   return (
     <List
       sx={{ width: 250, bgcolor: "background" }}
@@ -18,11 +25,11 @@ const Sidemenu = () => {
         </ListSubheader>
       }
     >
-      <ListItemButton>
+      <ListItemButton onClick={() => ToIndexArticle()}>
         <ListItemIcon>
           <ArticleOutlinedIcon />
         </ListItemIcon>
-        <Link href="/article/index">Index Article</Link>
+        Index Article
       </ListItemButton>
       <ListItemButton>
         <ListItemText primary="Drafts" />


### PR DESCRIPTION
### 概要
サイドメニューから記事一覧画面へ遷移時にサイドメニューが開いたままになる現象の修正

### 確認方法
- サイドメニューの記事一覧をクリックし、サイドメニューが閉じることを確認