### PR TITLE
マイページのカレンダーに取得した記事情報を追加

### DIFF
--- a/backend/app/controllers/api/v1/articles_controller.rb
+++ b/backend/app/controllers/api/v1/articles_controller.rb
@@ -58,6 +58,20 @@ class Api::V1::ArticlesController < ApplicationController
     render status: :ok
   end
 
+  def month_data
+    date = Date.parse(params[:date])
+    month_articles = current_api_v1_user.articles.where(publish_day: date.all_month)
+    month_articles_hash = month_articles.map do |article|
+      {
+        id: article.id,
+        title: article.title,
+        start: article.publish_day,
+        allDay: true,
+      }
+    end
+    render json: month_articles_hash, status: :ok
+  end
+
   private
 
   def article_params

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -6,11 +6,13 @@ Rails.application.routes.draw do
         registrations: 'auth/registrations'
       }
 
+      get '/articles/month_data/:date', to: 'articles#month_data'
       resources :articles do
         member do
           get 'edit'
         end
       end
+
     end
   end
 end

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -25,3 +25,15 @@ body {
 .editor-container {
   height: 90vh;
 }
+
+/* FullCalenderオーバーラップ */
+.fc-direction-ltr .fc-daygrid-event.fc-event-end,
+.fc-event-main-frame {
+  flex-direction: column;
+  text-align: center;
+}
+
+.fc-event-desc,
+.event-title-link {
+  white-space: normal;
+}

--- a/frontend/src/app/mypage/page.js
+++ b/frontend/src/app/mypage/page.js
@@ -1,60 +1,81 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { withAuthServerSideProps } from "../../../lib/auth";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
-import Link from "next/link";
 import Cookies from "js-cookie";
+import axios from "axios";
+import { Link } from "@mui/material";
 
-const Mypage = () => {
+const MyPage = () => {
   withAuthServerSideProps("/api/v1/mypage");
   // const handleDateClick = (arg) => {
   //   alert(arg.dateStr);
+  //   console.log(arg);
   // };
-
-  const [name, setName] = useState("");
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const name = await Cookies.get("name");
-      setName(name);
+  const generateEvents = (info, successCallback) => {
+    const getMonthData = async () => {
+      try {
+        const res = await axios.get(
+          `${process.env.NEXT_PUBLIC_BACKEND_URL}` +
+            "/api/v1/articles/month_data/" +
+            `${info.startStr}`,
+          {
+            headers: {
+              uid: Cookies.get("uid"),
+              client: Cookies.get("client"),
+              "access-token": Cookies.get("access-token"),
+            },
+          }
+        );
+        successCallback(res.data);
+      } catch (error) {
+        console.error(error);
+      }
     };
-    fetchData();
-  }, []);
+    getMonthData();
+  };
 
   return (
     <>
-      <div>
-        <div>ユーザー名：{name}</div>
-        <div className="calendar-container px-12 py-10">
-          <FullCalendar
-            plugins={[dayGridPlugin, interactionPlugin]}
-            headerToolbar={{
-              start: "prevYear,nextYear",
-              center: "title",
-              end: "today prev,next",
-            }}
-            initialView="dayGridMonth"
-            // dateClick={handleDateClick}
-            eventContent={renderEventContent}
-            contentHeight={"40em"}
-            events={[{ title: "event 1", date: "2024-03-15" }]}
-          />
-        </div>
+      <div className="calendar-container px-16 py-10">
+        <FullCalendar
+          plugins={[dayGridPlugin, interactionPlugin]}
+          headerToolbar={{
+            start: "prevYear,nextYear",
+            center: "title",
+            end: "today prev,next",
+          }}
+          initialView="dayGridMonth"
+          showNonCurrentDates={false}
+          // dateClick={handleDateClick}
+          eventContent={renderEventContent}
+          contentHeight={"40em"}
+          events={generateEvents}
+          eventBackgroundColor="white"
+          eventBorderColor="white"
+          eventTextColor="black"
+        />
       </div>
     </>
   );
 };
 
-// コンテンツの挿入
-// 記事コンポーネントを入れる
-function renderEventContent(eventInfo) {
+// イベントコンポーネント
+const renderEventContent = (eventInfo) => {
   return (
     <>
-      <Link href="/">{eventInfo.event.title}</Link>
+      <Link
+        href={`/article/${eventInfo.event.id}`}
+        color="inherit"
+        sx={{ fontWeight: "bold" }}
+        className="event-title-link"
+      >
+        {eventInfo.event.title}
+      </Link>
     </>
   );
-}
-export default Mypage;
+};
+
+export default MyPage;

--- a/frontend/src/components/navigation/navbar.js
+++ b/frontend/src/components/navigation/navbar.js
@@ -48,6 +48,9 @@ const NavBar = () => {
           <Button color="inherit">
             <Link href="/article/new">New Article</Link>
           </Button>
+          <Button color="inherit">
+            <Link href="/mypage">My Page</Link>
+          </Button>
         </Toolbar>
       </AppBar>
       <Drawer open={open} onClose={toggleDrawer}>


### PR DESCRIPTION
 ### 概要
- マイページのカレンダーへ記事情報を反映
- カレンダーの記事タイトルに記事詳細画面へのリンクを追加
- 関連API作成

### 確認方法

1. マイページにアクセス時記事情報が取得できていることを確認
2. 記事タイトルをクリックし、記事詳細画面へ遷移することを確認

### コメント
-1日に複数記事が投稿されると全て表示されてレイアウトが崩れてしまうので、１記事までの制限が必要かと考えています

### 参考資料
https://www.outsystems.com/forums/discussion/86052/fullcalendar-reactive-how-to-break-into-new-line/