### PR TITLE
詳細画面での編集・削除ボタン表示

### DIFF
--- a/backend/app/controllers/api/v1/articles_controller.rb
+++ b/backend/app/controllers/api/v1/articles_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ArticlesController < ApplicationController
   include Pagination
-  before_action :authenticate_api_v1_user!, except: :index
+  before_action :authenticate_api_v1_user!, except: [:index, :show]
 
   def index
     articles = Article.all.includes(:user).order(created_at: :desc)
@@ -55,6 +55,7 @@ class Api::V1::ArticlesController < ApplicationController
         id: article.id,
         title: article.title,
         content: article.content,
+        author: article.user.name
       }
       render json: article_hash, status: :ok
     end

--- a/frontend/src/app/article/[id]/page.js
+++ b/frontend/src/app/article/[id]/page.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Box, Container, Typography, IconButton, Table } from "@mui/material";
+import { Box, Container, Typography, IconButton } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import axios from "axios";
@@ -19,6 +19,8 @@ import { useRouter } from "next/navigation";
 const ShowArticle = ({ params }) => {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
+  const [author, setAuthor] = useState("");
+  const [name, setName] = useState("");
   const { id } = params;
 
   const router = useRouter();
@@ -40,6 +42,8 @@ const ShowArticle = ({ params }) => {
         );
         setTitle(res.data.title);
         setContent(res.data.content);
+        setAuthor(res.data.author);
+        setName(Cookies.get("name"));
       } catch (error) {
         console.error(error);
       }
@@ -103,23 +107,25 @@ const ShowArticle = ({ params }) => {
             {title}
           </Typography>
         </Box>
-        <Box
-          my={1}
-          flexDirection="row"
-          justifyContent="flex-end"
-          display="flex"
-        >
-          <Box>
-            <IconButton component={Link} href={`/article/${id}/edit`}>
-              <EditIcon />
-            </IconButton>
-          </Box>
-          <Box>
+        {name === author && (
+          <Box
+            my={1}
+            flexDirection="row"
+            justifyContent="flex-end"
+            display="flex"
+          >
+            <Link href={`/article/${id}/edit`}>
+              <IconButton>
+                <EditIcon />
+              </IconButton>
+            </Link>
+
             <IconButton onClick={() => DeleteArticle()}>
               <DeleteIcon />
             </IconButton>
           </Box>
-        </Box>
+        )}
+
         <Box sx={{ px: 4, py: 4 }}>
           <Markdown
             rehypePlugins={[rehypeRaw, rehypeSanitize]}

--- a/frontend/src/components/navigation/navbar.js
+++ b/frontend/src/components/navigation/navbar.js
@@ -60,6 +60,7 @@ const NavBar = () => {
       Cookies.remove("uid");
       Cookies.remove("client");
       Cookies.remove("access-token");
+      Cookies.remove("name");
       router.push("/");
       mutate(`${process.env.NEXT_PUBLIC_BACKEND_URL}` + "/api/v1/authenticate");
     } catch (err) {


### PR DESCRIPTION
### 概要
ログインユーザーが作成した記事の詳細画面でのみ編集・削除ボタンを表示させるよう修正

### 確認方法

1. ログインユーザが作成した記事を表示し、編集・削除ボタンが表示されることを確認
2. ログインユーザ以外が作成した記事を表示し、編集・削除ボタンが表示されないことを確認

### 参考資料
下記エラーへの対応方法
```
Warning: Did not expect server HTML to contain a <a> in<div>.
An error occurred during hydration. The server HTML was replaced with client content in <#document>.
on-recoverable-error.js:20 Uncaught Error: Hydration failed because the initial UI does not match what was rendered on the server.
Uncaught Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.
```

https://nextjs.org/docs/messages/react-hydration-error#solution-1-using-useeffect-to-run-on-the-client-only

#54 